### PR TITLE
Align json version to current git release

### DIFF
--- a/minemeld.json
+++ b/minemeld.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1b6",
+    "version": "0.1b8",
     "name": "minemeld-taxii-ng",
     "author": "Palo Alto Networks",
     "author_email": "techbizdev@paloaltonetworks.com",


### PR DESCRIPTION
Version on minemeld.json is not in sync with git release (0.1b8 on 24 Feb 2018)